### PR TITLE
tsのtargetをES2018に

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES2018",
     "lib": ["esnext", "dom", "dom.iterable"],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
- Optional Chainingなどが残ってしまっていたため