### PR TITLE
:sparkles: Add TLDs

### DIFF
--- a/src/traQMarkdownIt.ts
+++ b/src/traQMarkdownIt.ts
@@ -87,6 +87,7 @@ export class traQMarkdownIt {
   }
 
   private setRendererRule(): void {
+    this.md.linkify.tlds(['app', 'dev', 'games', 'tech', 'show'], true)
     this.md.block.State.prototype.skipEmptyLines = function skipEmptyLines(
       from: number
     ): number {

--- a/tests/__snapshots__/traQMarkdownIt.test.ts.snap
+++ b/tests/__snapshots__/traQMarkdownIt.test.ts.snap
@@ -14,6 +14,8 @@ exports[` 6`] = `"<span class="katex"><span class="katex-html" aria-hidden="true
 
 exports[` 7`] = `"<span class="katex"><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8988em;vertical-align:-0.2155em;"></span><span class="mord text"><span class="mord textrm">K</span><span class="mspace" style="margin-right:-0.17em;"></span><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.6833em;"><span style="top:-2.905em;"><span class="pstrut" style="height:2.7em;"></span><span class="mord"><span class="mord textrm mtight sizing reset-size6 size3">A</span></span></span></span></span></span><span class="mspace" style="margin-right:-0.15em;"></span><span class="mord text"><span class="mord textrm">T</span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height:0.4678em;"><span style="top:-2.7845em;"><span class="pstrut" style="height:3em;"></span><span class="mord"><span class="mord textrm">E</span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height:0.2155em;"><span></span></span></span></span><span class="mspace" style="margin-right:-0.125em;"></span><span class="mord textrm">X</span></span></span></span></span></span>"`;
 
+exports[` 8`] = `"<a href="http://example.dev" target="_blank" rel="nofollow noopener noreferrer">example.dev</a> <a href="http://example.show" target="_blank" rel="nofollow noopener noreferrer">example.show</a>"`;
+
 exports[`index can render 1`] = `
 "<p><strong>po</strong><br>
 :xx:<br>

--- a/tests/traQMarkdownIt.test.ts
+++ b/tests/traQMarkdownIt.test.ts
@@ -139,6 +139,24 @@ describe('index', () => {
       expected: {
         embeddings: []
       }
+    },
+    {
+      input: dedent`
+        example.dev
+        example.show
+      `,
+      expected: {
+        embeddings: [
+          {
+            type: 'url',
+            url: 'http://example.dev'
+          },
+          {
+            type: 'url',
+            url: 'http://example.show'
+          }
+        ]
+      }
     }
   ]
 


### PR DESCRIPTION
`vitest.dev`などがこれだけだとリンクにならない(`trap.jp`などはリンクになる)のを、リンクが貼られるようにしました