### PR TITLE
use own markdown-it-regexp plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@traptitech/markdown-it-katex": "^3.5.0",
-        "@traptitech/markdown-it-regexp": "^0.5.3",
         "@traptitech/markdown-it-spoiler": "^1.1.6",
         "highlight.js": "^11.3.1",
         "katex": "^0.16.0",
@@ -1176,11 +1175,6 @@
       "dependencies": {
         "katex": "^0.16.0"
       }
-    },
-    "node_modules/@traptitech/markdown-it-regexp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@traptitech/markdown-it-regexp/-/markdown-it-regexp-0.5.3.tgz",
-      "integrity": "sha512-1PhwqY/vsef2OI8xOxUTGTPTMW3J65AG1LhKhkTJFgNVsu6tN9LGVBz/Y8vKPNNXuZOxhUWR3Xg8N91Dx3aH4A=="
     },
     "node_modules/@traptitech/markdown-it-spoiler": {
       "version": "1.1.6",
@@ -6576,11 +6570,6 @@
       "requires": {
         "katex": "^0.16.0"
       }
-    },
-    "@traptitech/markdown-it-regexp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@traptitech/markdown-it-regexp/-/markdown-it-regexp-0.5.3.tgz",
-      "integrity": "sha512-1PhwqY/vsef2OI8xOxUTGTPTMW3J65AG1LhKhkTJFgNVsu6tN9LGVBz/Y8vKPNNXuZOxhUWR3Xg8N91Dx3aH4A=="
     },
     "@traptitech/markdown-it-spoiler": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "homepage": "https://github.com/traPtitech/traq-markdown-it#readme",
   "dependencies": {
     "@traptitech/markdown-it-katex": "^3.5.0",
-    "@traptitech/markdown-it-regexp": "^0.5.3",
     "@traptitech/markdown-it-spoiler": "^1.1.6",
     "highlight.js": "^11.3.1",
     "katex": "^0.16.0",

--- a/src/regexpPlugin.ts
+++ b/src/regexpPlugin.ts
@@ -1,0 +1,56 @@
+/*!
+ * markdown-it-regexp
+ * Copyright (c) 2014 Alex Kocharin
+ * MIT Licensed
+ */
+
+import MarkdownIt from 'markdown-it'
+import Token from 'markdown-it/lib/token'
+
+export default function RegexpPlugin(
+  regexp: RegExp,
+  replacer: (match: RegExpMatchArray) => string
+): (md: MarkdownIt) => void {
+  let counter = 0
+
+  return function (md) {
+    const flags =
+      (regexp.global ? 'g' : '') +
+      (regexp.multiline ? 'm' : '') +
+      (regexp.ignoreCase ? 'i' : '')
+    const parsedRegexp = RegExp('^' + regexp.source, flags)
+    const id = 'regexp-' + counter++
+
+    md.inline.ruler.push(id, (state, silent) => {
+      // slowwww... maybe use an advanced regexp engine for this
+      const match = parsedRegexp.exec(state.src.slice(state.pos))
+      if (!match) return false
+
+      if (state.pending) {
+        state.pushPending()
+      }
+
+      // valid match found, now we need to advance cursor
+      const oldPos = state.pos
+      state.pos += match[0].length
+
+      // don't insert any tokens in silent mode
+      if (silent) return true
+
+      const token = state.push(id, '', 0) as Token & {
+        meta: { match: RegExpMatchArray }
+        position: number
+        size: number
+      }
+      token.meta = { match: match }
+      token.position = oldPos
+      token.size = match[0].length
+
+      return true
+    })
+
+    md.renderer.rules[id] = (tokens, idx) => {
+      return replacer(tokens[idx]?.meta.match)
+    }
+  }
+}

--- a/src/stamp.ts
+++ b/src/stamp.ts
@@ -1,5 +1,5 @@
 import type MarkdownIt from 'markdown-it'
-import regexp from '@traptitech/markdown-it-regexp'
+import regexp from './regexpPlugin'
 import { escapeHtml } from './util'
 import type { Store } from './Store'
 import { animeEffects, sizeEffects } from './data/stampEffects'

--- a/src/stampCss.ts
+++ b/src/stampCss.ts
@@ -1,5 +1,5 @@
 import type MarkdownIt from 'markdown-it'
-import regexp from '@traptitech/markdown-it-regexp'
+import regexp from './regexpPlugin'
 
 // See stamp.ts stampRegExp
 const stampRegExp = /:(?:[a-zA-Z0-9+_-]{1,32}|@[a-zA-Z0-9_-]+)(?:\.[\w+-.]+)?:/


### PR DESCRIPTION
どうしてもDenoで動かしたかったんですが、@traptitech/markdown-it-regexpが古く動かなかったのでTypeScriptで書きなおしました
テストは通ってるので大丈夫だとは思いますが確認していただけると助かります

元: https://github.com/traPtitech/markdown-it-regexp/blob/master/lib/index.js