### PR TITLE
chore: dependabot のグルーピング & actions 系の追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     groups:
       markdown-it:
         patterns:
-          - "*markdown-it*"
+          - '*markdown-it*'
       jest:
         patterns:
           - '*jest*'


### PR DESCRIPTION
アプデの件数が多いのでグルーピングしました
あと、特に eslint 周りは plugin の影響で peerDependency の解決に失敗して CI が落ちやすいので、その対策も兼ねています