### PR TITLE
chore: peerDependenciesで@traptitech/traqのプレリリースを許容し、patchバージョンを更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@traptitech/traq-markdown-it",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@traptitech/traq-markdown-it",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@traptitech/markdown-it-katex": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/traPtitech/traq-markdown-it#readme",
   "peerDependencies": {
-    "@traptitech/traq": ">=3.0.0 <4.0.0"
+    "@traptitech/traq": ">=3.0.0-0 <4.0.0"
   },
   "dependencies": {
     "@traptitech/markdown-it-katex": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traptitech/traq-markdown-it",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Markdown parser for traQ.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
ref: https://www.npmjs.com/package/@traptitech/traq?activeTab=versions
@traptitech/traq のバージョンにはプレリリース版しかないので、以前の書き方だと peerDependenciesを満たすバージョンが存在しなかった