### PR TITLE
chore: @traptitech/traq の peerDependencies を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "url": "https://github.com/traPtitech/traq-markdown-it/issues"
   },
   "homepage": "https://github.com/traPtitech/traq-markdown-it#readme",
-  "peerDependencies": {
-    "@traptitech/traq": ">=3.0.0-0 <4.0.0"
-  },
   "dependencies": {
     "@traptitech/markdown-it-katex": "^3.5.0",
     "@traptitech/markdown-it-regexp": "^0.5.3",


### PR DESCRIPTION
理由：
- semver の仕様上、peerDependencies で「3.x の全プレリリース版」を一括で含める指定はできない
  - プレリリースがある特定の [major.minor.patch] の比較子と一致しないプレリリースはレンジにマッチしないため
- 現状 @traptitech/traq は安定版がなく、プレリリースしか存在しないため、どのキャレットまたは固定指定でも peerDependencies 要求を満たせない