### PR TITLE
fix: export traQMarkdownIt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@traptitech/traq": ">=3.0.0 <4.0.0"
+        "@traptitech/traq": ">=3.0.0-0 <4.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,13 @@ export type {
   EmbeddingFile,
   EmbeddingMessage
 } from './embeddingExtractor'
-export type { MarkdownRenderResult, traQMarkdownIt } from './traQMarkdownIt'
+export type { MarkdownRenderResult } from './traQMarkdownIt'
 export type { AnimeEffect, SizeEffect } from './stamp'
 
 export { createHighlightFunc } from './highlight'
 export { default as markPlugin } from 'markdown-it-mark'
 export { default as spoilerPlugin } from '@traptitech/markdown-it-spoiler'
+export { traQMarkdownIt } from './traQMarkdownIt'
 export { default as stampPlugin, animeEffectSet, sizeEffectSet } from './stamp'
 export { default as jsonPlugin } from './json'
 export { default as katexPlugin } from '@traptitech/markdown-it-katex'


### PR DESCRIPTION
traQMarkdownItはclassだがtype exportしかされてなかったのでesmでimport errorになってしまっていた